### PR TITLE
added early returns

### DIFF
--- a/app/utils/landscape-rendering/klay-layouter.js
+++ b/app/utils/landscape-rendering/klay-layouter.js
@@ -293,6 +293,14 @@ export default function applyKlayLayout(landscape) {
 
           let appSource = applicationcommunication.get('sourceApplication');
           let appTarget = applicationcommunication.get('targetApplication');
+          
+          if(appSource == null || appTarget == null) {
+            return;
+          }
+
+          if(appSource.get('parent') == null || appTarget.get('parent') == null) {
+            return;
+          }
           //console.log("edge: " + appSource.get('name') + " -> " + appTarget.get('name'));
 
           if(!appTarget.get('parent').get('visible')){
@@ -552,7 +560,8 @@ export default function applyKlayLayout(landscape) {
             y: 0
           };
 
-
+          if(targetDrawnode.get('kielerGraphReference') == null)return;
+          
           port.node = targetDrawnode.get('kielerGraphReference');
 
           targetDrawnode.get('kielerGraphReference').ports.push(port);

--- a/app/utils/landscape-rendering/klay-layouter.js
+++ b/app/utils/landscape-rendering/klay-layouter.js
@@ -560,7 +560,9 @@ export default function applyKlayLayout(landscape) {
             y: 0
           };
 
-          if(targetDrawnode.get('kielerGraphReference') == null)return;
+          if(targetDrawnode.get('kielerGraphReference') == null) {
+            return;
+          }
           
           port.node = targetDrawnode.get('kielerGraphReference');
 


### PR DESCRIPTION
which are used to get no more errors, that are not handled anyways.

these should not harm the visualization process in any way, just ignore some potential missformations of a landscape.