### PR TITLE
Trace Replayer enhancement

### DIFF
--- a/app/components/visualization/page-setup/sidebar/trace-selection.js
+++ b/app/components/visualization/page-setup/sidebar/trace-selection.js
@@ -31,7 +31,6 @@ export default Component.extend({
   }),
 
   filterAndSortTraces(traces) {
-
     if (!traces) {
       return [];
     }
@@ -131,8 +130,7 @@ export default Component.extend({
         // Sort in ascending order by default
         this.set('isSortedAsc', true);
       }
-
-      // Set property by which shall be sorted
+      
       this.set('sortBy', property);
     },
 
@@ -145,10 +143,10 @@ export default Component.extend({
     let currentTraceStep = this.get('highlighter.currentTraceStep');
 
     if (currentTraceStep) {
-      let storeId = currentTraceStep.get('clazzCommunication.sourceClazz.id');
+      let storeId = currentTraceStep.get('clazzCommunication.id');
       // Avoid proxy object by requesting clazz from store
-      let originClazz = this.get('store').peekRecord('clazz', storeId);
-      this.get('renderingService').moveCameraTo(originClazz);
+      let clazzCommunication = this.get('store').peekRecord('clazzcommunication', storeId);
+      this.get('renderingService').moveCameraTo(clazzCommunication);
     }
   },
 

--- a/app/components/visualization/rendering/application-rendering.js
+++ b/app/components/visualization/rendering/application-rendering.js
@@ -80,7 +80,7 @@ export default RenderingCore.extend(AlertifyHandler, {
 
     // Move camera to specified position
     this.onMoveCameraTo = function (emberModel) {
-      if (!emberModel){
+      if (!emberModel) {
         return;
       }
 
@@ -88,11 +88,20 @@ export default RenderingCore.extend(AlertifyHandler, {
       // Position of object in local coordinates
       let position, zoom;
 
-      if (emberModelName === "clazz"){
+      if (emberModelName === "clazz") {
         position = new THREE.Vector3(emberModel.get('positionX'), emberModel.get('positionY'), emberModel.get('positionZ'));
         zoom = 50;
+      } else if (emberModelName === "clazzcommunication") {
+        let sourceClazz = emberModel.get('sourceClazz');
+        let targetClazz = emberModel.get('targetClazz');
+        // Set middle point of communication as position
+        position = new THREE.Vector3(
+          sourceClazz.get('positionX') + 0.5 * (targetClazz.get('positionX') - sourceClazz.get('positionX')),
+          sourceClazz.get('positionY') + 0.5 * (targetClazz.get('positionY') - sourceClazz.get('positionY')),
+          sourceClazz.get('positionZ') + 0.5 * (targetClazz.get('positionZ') - sourceClazz.get('positionZ')));
+        zoom = 50;
       } else {
-        // Position and zoom of model not (yet) defined
+        // Given model not yet supported for moving camera
         return;
       }
 

--- a/app/components/visualization/rendering/application-rendering.js
+++ b/app/components/visualization/rendering/application-rendering.js
@@ -98,23 +98,17 @@ export default RenderingCore.extend(AlertifyHandler, {
       if (emberModelName === "clazz") {
         position = new THREE.Vector3(emberModel.get('positionX'), emberModel.get('positionY'), emberModel.get('positionZ'));
         applyCameraPosition(this.get('application3D'), viewCenterPoint, this.get('camera'), position);
-        this.get('application3D').localToWorld(position);
         // Apply zoom
         this.get('camera').position.z += 25;
       } else if (emberModelName === "clazzcommunication") {
         let sourceClazz = emberModel.get('sourceClazz');
         let targetClazz = emberModel.get('targetClazz');
-        // Set middle point of communication as position
-        let startPosition = new THREE.Vector3(sourceClazz.get('positionX'), sourceClazz.get('positionY'), sourceClazz.get('positionZ'));
-        let endPosition = new THREE.Vector3(targetClazz.get('positionX'), targetClazz.get('positionY'), targetClazz.get('positionZ'));
-
-        this.get('application3D').localToWorld(startPosition);
-        this.get('application3D').localToWorld(endPosition);
 
         position = new THREE.Vector3(
           sourceClazz.get('positionX') + 0.5 * (targetClazz.get('positionX') - sourceClazz.get('positionX')),
           sourceClazz.get('positionY') + 0.5 * (targetClazz.get('positionY') - sourceClazz.get('positionY')),
           sourceClazz.get('positionZ') + 0.5 * (targetClazz.get('positionZ') - sourceClazz.get('positionZ')));
+
         applyCameraPosition(this.get('application3D'), viewCenterPoint, this.get('camera'), position);
         // Apply zoom
         this.get('camera').position.z += 50;

--- a/app/models/component.js
+++ b/app/models/component.js
@@ -32,10 +32,7 @@ export default Draw3DNodeEntity.extend({
   parentComponent: belongsTo('component', {
     inverse: 'children'
   }),
-
-  // why is this overriden here?
-  //opened: false,
-
+  
   // breaks Ember, maybe because of circle ?
 
   /*belongingApplication: belongsTo('application', {


### PR DESCRIPTION
Enhanced camera positioning of trace replayer and did a minor refactoring: Trace replayer now centers camera around the clazz communication. However, the zoom level is still computed statically because a first attempt to calculate the required zoom with the help of frustum was not successful.