### PR TITLE
Replace ember spinners with bootstrap spinners

### DIFF
--- a/app/styles/_main.scss
+++ b/app/styles/_main.scss
@@ -174,16 +174,22 @@ svg.octicon {
   border-color: #9be7ff;
 }
 
-.spinner-center {
-  @extend .spinner-border;
-  position: absolute;
-  top: 50%;
-  left: calc(50% - 1.5rem);
-  width: 3rem;
-  height: 3rem;
+@mixin centerSpinners() {
+  @for $i from 1 through 5 {
+    .spinner-center-#{$i} {
+      @extend .spinner-border;
+      position: absolute;
+      top: calc(50% - #{$i/2}rem);
+      left: calc(50% - #{$i/2}rem);
+      width: #{$i}rem;
+      height: #{$i}rem;
+    }
+  }
 }
 
-.spinner-center-relative {
+* { @include centerSpinners(); }
+
+.spinner-center-3-relative {
   @extend .spinner-border;
   width: 3rem;
   height: 3rem;

--- a/app/templates/components/discovery/agent-details.hbs
+++ b/app/templates/components/discovery/agent-details.hbs
@@ -1,9 +1,9 @@
 {{#if showSpinner}}
   <div class="explorVizModal">
-    {{ember-spinner lines=11 length=16 radius=30 width=8 rotate=10 speed='1.1' color="#ffffff"}}
+    <div class="spinner-center-5" style="color: white">
+    </div>
   </div>
 {{/if}}
-
 
 <div class="btn-group align-self-center d-block" role="group">
   <button {{action "saveAgent"}} type="button" class="btn btn-secondary">Save</button>

--- a/app/templates/components/discovery/node-overview.hbs
+++ b/app/templates/components/discovery/node-overview.hbs
@@ -5,7 +5,7 @@
       <p>Go to Settings an enable 'Show hidden entities' or click <a {{action "enableShowHidden" preventDefault=false}}>here</a>
       </p>
     </div>
-    <div class="spinner-center" role="status"></div>
+    <div class="spinner-center-3" role="status"></div>
   </div>
 {{else}}
   {{#if agentRepo.agentList}}
@@ -22,7 +22,7 @@
         <p>No agent registered with the backend at the moment. A new list will be fetched every 10 seconds.</p>
       </div>
       <div class="d-flex justify-content-center">
-        <div class="spinner-center-relative" role="status">
+        <div class="spinner-center-3-relative" role="status">
         </div>
       </div>
     </div>

--- a/app/templates/components/discovery/procezz-details.hbs
+++ b/app/templates/components/discovery/procezz-details.hbs
@@ -1,6 +1,7 @@
 {{#if showSpinner}}
   <div class="explorVizModal">
-    {{ember-spinner lines=11 length=16 radius=30 width=8 rotate=10 speed='1.1' color="#ffffff"}}
+    <div class="spinner-center-5" style="color: white">
+    </div>
   </div>
 {{/if}}
 

--- a/app/templates/components/user-management/user-list.hbs
+++ b/app/templates/components/user-management/user-list.hbs
@@ -24,7 +24,7 @@ https://github.com/kaliber5/ember-bootstrap/issues/441}}
   </div>
   <div class="d-flex flex-grow-1" style="overflow-y: auto">
     {{#if this.showSpinner}}
-      <div class="spinner-center" role="status"></div>
+      <div class="spinner-center-3" role="status"></div>
     {{/if}}
     <table class="table table-striped">
       <thead class="thead-light">

--- a/app/templates/components/user-management/user-settings-base.hbs
+++ b/app/templates/components/user-management/user-settings-base.hbs
@@ -1,6 +1,6 @@
 
 {{#if this.loadDescription.isRunning}}
-  <div class="spinner-center" role="status"></div>
+  <div class="spinner-center-3" role="status"></div>
 {{else}}
   {{#bs-form model=this as |form|}}
     {{#each-in this.settings.booleanAttributes as |key|}}

--- a/app/templates/components/user-management/user-settings.hbs
+++ b/app/templates/components/user-management/user-settings.hbs
@@ -3,7 +3,7 @@
   <hr>
   <div class="mt-2">
     {{#if this.copySettings.isRunning}}
-      <div class="spinner-center" role="status"></div>
+      <div class="spinner-center-3" role="status"></div>
     {{else}}
       {{user-management/user-settings-base settings=this.settings}}
 

--- a/app/templates/visualization.hbs
+++ b/app/templates/visualization.hbs
@@ -22,7 +22,7 @@
           <h2>No Landscape Found!</h2>
           <p>A new landscape will be fetched every 10 seconds.</p>
         </div>
-        <div class="spinner-center" role="status"></div>
+        <div class="spinner-center-3" role="status"></div>
       </div>
     {{/if}}
     {{else}}

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "ember-cli-babel": "^7.4.0",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-node-modules-to-vendor": "^0.3.0",
-    "ember-cli-spinjs": "2.1.1",
     "ember-data": "^3.7.0",
     "ember-link-action": "0.1.3",
     "ember-resolver": "^5.0.1",


### PR DESCRIPTION
Closes #140 
Ember spinners have all been replaced.
Furthermore, I added a mixin that generates css classes `spinner-center-[1,..,5]`. They replace the former `spinner-center` and come in different sizes depending on the number suffix.