### PR TITLE
Fixes

### DIFF
--- a/app/components/visualization/page-setup/navbar/application-search.js
+++ b/app/components/visualization/page-setup/navbar/application-search.js
@@ -9,11 +9,9 @@ export default Component.extend({
 
   tagName: "",
 
-  store: service(),
   renderingService: service(),
   landscapeRepo: service('repos/landscape-repository'),
   highlighter: service('visualization/application/highlighter'),
-  addionalData: service("additional-data"),
 
   selectedEntity: null,
 

--- a/app/routes/configuration/usermanagement/edit.ts
+++ b/app/routes/configuration/usermanagement/edit.ts
@@ -17,6 +17,9 @@ export default class UserManagementEditRoute extends BaseRoute.extend(Authentica
       return {
         user
       };
+    }, () => {
+      this.showAlertifyWarning('User was not found.');
+      this.transitionTo('configuration.usermanagement');
     });
   }
 
@@ -28,23 +31,6 @@ export default class UserManagementEditRoute extends BaseRoute.extend(Authentica
 
     goBack(this: UserManagementEditRoute) {
       this.transitionTo('configuration.usermanagement');
-    },
-
-    error(this: UserManagementEditRoute, error:any) {
-      let notFound = error === 'not-found' ||
-        (error &&
-          error.errors &&
-          error.errors[0] &&
-          error.errors[0].status == 404);
-
-      // routes that can't find models
-      if (notFound) {
-        this.showAlertifyMessage('Error: User was not found.');
-        this.transitionTo('configuration.usermanagement');
-        return;
-      } else {
-        return true;
-      }
     }
   }
 }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,4 +1,4 @@
-import Route from '@ember/routing/route';
+import BaseRoute from 'explorviz-frontend/routes/base-route';
 import UnauthenticatedRouteMixin from
  'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
@@ -8,6 +8,12 @@ import UnauthenticatedRouteMixin from
 * @class Login-Route
 * @extends Ember.Route
 */
-export default Route.extend(UnauthenticatedRouteMixin, {
-    routeIfAlreadyAuthenticated: 'visualization'
+export default BaseRoute.extend(UnauthenticatedRouteMixin, {
+  routeIfAlreadyAuthenticated: 'visualization',
+
+  // @Override BaseRoute
+  actions: {
+    resetRoute() {
+    }
+  }
 });

--- a/app/utils/application-rendering/labeler.ts
+++ b/app/utils/application-rendering/labeler.ts
@@ -9,8 +9,8 @@ export default Object.extend({
   textMaterialFoundation: null,
   textMaterialComponent: null,
   textMaterialClazz: null,
-  currentUser: null,
 
+  currentUser: service(),
   session: service(),
   configuration: service(),
 


### PR DESCRIPTION
- In the application laber, the currentUser service is now correcly injected.

- When in login mask, accessing the edit route of the user-management s.a `http://localhost:4200/configuration/usermanagement/edit/5` and then logging in was causing the `resetRoute` action in the `login` route to be called, but it did not exist. The `login` route now extends from `base-route` and contains a `resetRoute` action.

- When accessing the edit route with a user id as path parameter, the route makes a `findRecord` call for that id. We now handle the case, that the user does not exist and alert the user accordingly.