### PR TITLE
Improve timeline's "No timestamps available" illustration

### DIFF
--- a/app/components/replay/page-setup/timeline/plotly-timeline.ts
+++ b/app/components/replay/page-setup/timeline/plotly-timeline.ts
@@ -143,6 +143,7 @@ export default class PlotlyTimeline extends Component.extend({
   setupPlotlyTimelineChart(timestamps: Timestamp[]) {
 
     if (!timestamps || timestamps.length == 0) {
+      this.createDummyTimeline();
       return;
     }
 
@@ -205,6 +206,15 @@ export default class PlotlyTimeline extends Component.extend({
       this.getPlotlyOptionsObject()
     );
   };
+
+  createDummyTimeline() {
+    Plotly.newPlot(
+      'plotlyDiv',
+      null,
+      this.getPlotlyLayoutObject(0, 90),
+      this.getPlotlyOptionsObject()
+    );
+  }
 
   // END Plot Logic
 

--- a/app/components/visualization/page-setup/timeline/plotly-timeline.ts
+++ b/app/components/visualization/page-setup/timeline/plotly-timeline.ts
@@ -181,6 +181,7 @@ export default class PlotlyTimeline extends Component.extend({
   setupPlotlyTimelineChart(timestamps : Timestamp[]) {
 
     if(!timestamps || timestamps.length == 0) {
+      this.createDummyTimeline();
       return;
     }
 
@@ -257,6 +258,15 @@ export default class PlotlyTimeline extends Component.extend({
   resetHighlighting() {
     this.resetHighlingInStateObjects();
     this.extendPlotlyTimelineChart(get(this, "timestamps"));
+  }
+
+  createDummyTimeline() {
+    Plotly.newPlot(
+      'plotlyDiv',
+      null,
+      this.getPlotlyLayoutObject(0, 90),
+      this.getPlotlyOptionsObject()
+    );
   }
 
   // END Plot Logic

--- a/app/styles/_timeline.scss
+++ b/app/styles/_timeline.scss
@@ -61,3 +61,29 @@
   margin-top: 50px;
   border-style: solid;
 }
+
+#timeline-no-timestamps-inner {
+  border: 1px black solid;
+  background: #85959a;
+  opacity: 0.9;
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  color: white;
+  text-shadow: 2px 2px 3px rgb(0, 0, 0);
+}
+
+#timeline-no-timestamps-outer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  position: absolute;
+  z-index: 20000;
+  width: 100%;
+  height: 150px;
+}
+
+.timeline-blur-effect {
+  filter: blur(.1rem) opacity(0.5);
+}

--- a/app/templates/components/replay/page-setup/timeline/plotly-timeline.hbs
+++ b/app/templates/components/replay/page-setup/timeline/plotly-timeline.hbs
@@ -1,7 +1,7 @@
 {{#unless timestamps.length}}
   <div id="timeline-no-timestamps-outer">
     <div id='timeline-no-timestamps-inner'>
-      No timestamps available!
+      No replay timestamps available!
     </div>
   </div>
   <div id='plotlyDiv' class="timeline-blur-effect"></div>

--- a/app/templates/components/replay/page-setup/timeline/plotly-timeline.hbs
+++ b/app/templates/components/replay/page-setup/timeline/plotly-timeline.hbs
@@ -1,7 +1,10 @@
-{{#if timestamps.length}}
-  <div id='plotlyDiv'></div>
-{{else}}
-  <div class="d-flex justify-content-center timeline-no-content">
-    No replay timestamps available.
+{{#unless timestamps.length}}
+  <div id="timeline-no-timestamps-outer">
+    <div id='timeline-no-timestamps-inner'>
+      No timestamps available!
+    </div>
   </div>
-{{/if}}
+  <div id='plotlyDiv' class="timeline-blur-effect"></div>
+{{else}}
+  <div id='plotlyDiv'></div>
+{{/unless}}

--- a/app/templates/components/visualization/page-setup/timeline/plotly-timeline.hbs
+++ b/app/templates/components/visualization/page-setup/timeline/plotly-timeline.hbs
@@ -1,7 +1,7 @@
 {{#unless timestamps.length}}
   <div id="timeline-no-timestamps-outer">
     <div id='timeline-no-timestamps-inner'>
-      No timestamps available.
+      No timestamps available!
     </div>
   </div>
   <div id='plotlyDiv' class="timeline-blur-effect"></div>

--- a/app/templates/components/visualization/page-setup/timeline/plotly-timeline.hbs
+++ b/app/templates/components/visualization/page-setup/timeline/plotly-timeline.hbs
@@ -1,7 +1,10 @@
-{{#if timestamps.length}}
-  <div id='plotlyDiv'></div>
-{{else}}
-  <div class="d-flex justify-content-center timeline-no-content">
-    No timestamps available.
+{{#unless timestamps.length}}
+  <div id="timeline-no-timestamps-outer">
+    <div id='timeline-no-timestamps-inner'>
+      No timestamps available.
+    </div>
   </div>
-{{/if}}
+  <div id='plotlyDiv' class="timeline-blur-effect"></div>
+{{else}}
+  <div id='plotlyDiv'></div>
+{{/unless}}

--- a/tests/integration/components/replay/page-setup/timeline/plotly-timeline-test.ts
+++ b/tests/integration/components/replay/page-setup/timeline/plotly-timeline-test.ts
@@ -15,7 +15,7 @@ module('Integration | Component | replay/page-setup/timeline/plotly-timeline', f
     const el:any = this.element;
 
     if(el) {
-      assert.equal(el.textContent.trim(), 'No replay timestamps available.');
+      assert.equal(el.textContent.trim(), 'No replay timestamps available!');
     } else {
       assert.notOk( "empty element", "There was no element to test." );
     }

--- a/tests/integration/components/replay/page-setup/timeline/plotly-timeline-test.ts
+++ b/tests/integration/components/replay/page-setup/timeline/plotly-timeline-test.ts
@@ -15,7 +15,7 @@ module('Integration | Component | replay/page-setup/timeline/plotly-timeline', f
     const el:any = this.element;
 
     if(el) {
-      assert.equal(el.textContent.trim(), 'No replay timestamps available!');
+      assert.ok(el.textContent.trim().includes('No replay timestamps available!'));
     } else {
       assert.notOk( "empty element", "There was no element to test." );
     }

--- a/tests/integration/components/visualization/page-setup/timeline/plotly-timeline-test.ts
+++ b/tests/integration/components/visualization/page-setup/timeline/plotly-timeline-test.ts
@@ -15,7 +15,7 @@ module('Integration | Component | visualization/page-setup/timeline/plotly-timel
       const el:any = this.element;
 
       if(el) {
-        assert.equal(el.textContent.trim(), 'No timestamps available.');
+        assert.equal(el.textContent.trim(), 'No timestamps available!');
       } else {
         assert.notOk( "empty element", "There was no element to test." );
       }

--- a/tests/integration/components/visualization/page-setup/timeline/plotly-timeline-test.ts
+++ b/tests/integration/components/visualization/page-setup/timeline/plotly-timeline-test.ts
@@ -15,7 +15,7 @@ module('Integration | Component | visualization/page-setup/timeline/plotly-timel
       const el:any = this.element;
 
       if(el) {
-        assert.equal(el.textContent.trim(), 'No timestamps available!');
+        assert.ok(el.textContent.trim().includes('No timestamps available!'));
       } else {
         assert.notOk( "empty element", "There was no element to test." );
       }


### PR DESCRIPTION
A dummy timeline was added to be displayed when there are no timestamps. The "No timestamps available" message was given some style improvements for a more modern look, which fits into the rest of ExplorViz.
This was done for both the plotly-timelines (i.e. visualization and replay).

Closes #182 